### PR TITLE
[mbta-rapid-transit-map] Add alerting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "editor.formatOnSave": true,
+    "editor.formatOnPaste": true
+}

--- a/ryanwallace.cloud/assets/css/custom.css
+++ b/ryanwallace.cloud/assets/css/custom.css
@@ -94,38 +94,45 @@ pre {
   background-color: #2f5da6 !important;
   color: white;
   font-weight: bold;
+  padding: 5px;
 }
 
 .gl {
   background-color: #008150 !important;
   color: white;
   font-weight: bold;
+  padding: 5px;
 }
 
 .rl {
   background-color: #fa2d27 !important;
   color: black;
   font-weight: bold;
+  padding: 5px;
 }
 
 .ol {
   background-color: #fd8a03 !important;
   color: black;
   font-weight: bold;
+  padding: 5px;
 }
 
 .cr {
   background-color: #7b388c !important;
   color: white;
   font-weight: bold;
+  padding: 5px;
 }
 
 .sl {
   background-color: #9a9c9d !important;
   color: black;
   font-weight: bold;
+  padding: 5px;
 }
 
 td {
   text-align: center;
+  padding: 5px;
 }

--- a/ryanwallace.cloud/assets/css/custom.css
+++ b/ryanwallace.cloud/assets/css/custom.css
@@ -136,3 +136,11 @@ td {
   text-align: center;
   padding: 5px;
 }
+
+.content div {
+  color: inherit !important;
+}
+
+.alert-body {
+  font-size: 16px;
+}

--- a/ryanwallace.cloud/map/package.json
+++ b/ryanwallace.cloud/map/package.json
@@ -9,6 +9,7 @@
     "@maptiler/leaflet-maptilersdk": "^4.0.2",
     "@petoc/leaflet-double-touch-drag-zoom": "^1.0.3",
     "datatables.net-dt": "^2.2.2",
+    "date-fns": "^4.1.0",
     "dompurify": "^3.2.5",
     "invert-color": "^2.0.0",
     "jquery": "^3.7.1",

--- a/ryanwallace.cloud/map/package.json
+++ b/ryanwallace.cloud/map/package.json
@@ -9,6 +9,7 @@
     "@maptiler/leaflet-maptilersdk": "^4.0.2",
     "@petoc/leaflet-double-touch-drag-zoom": "^1.0.3",
     "invert-color": "^2.0.0",
+    "jquery": "^3.7.1",
     "leaflet": "^1.9.4",
     "leaflet-arrowheads": "^1.4.0",
     "leaflet-easybutton": "^2.4.0",

--- a/ryanwallace.cloud/map/package.json
+++ b/ryanwallace.cloud/map/package.json
@@ -8,6 +8,8 @@
   "dependencies": {
     "@maptiler/leaflet-maptilersdk": "^4.0.2",
     "@petoc/leaflet-double-touch-drag-zoom": "^1.0.3",
+    "datatables.net-dt": "^2.2.2",
+    "dompurify": "^3.2.5",
     "invert-color": "^2.0.0",
     "jquery": "^3.7.1",
     "leaflet": "^1.9.4",
@@ -24,6 +26,6 @@
     "build": "parcel build src/index.html --public-url /map/",
     "move": "mkdir -p ../static/map; mkdir -p ../content/map; mv dist/*.css* ../static/map/; mv dist/*.js* ../static/map/; mv dist/*.html ../content/map/ ",
     "title": "cat head.md ../content/map/index.html >  temp; mv temp ../content/map/index.html",
-    "clean": "rm ../content/map/*; rm ../static/map/*"
+    "clean": "rm -f ../content/map/*; rm -f ../static/map/*"
   }
 }

--- a/ryanwallace.cloud/map/src/index.html
+++ b/ryanwallace.cloud/map/src/index.html
@@ -118,6 +118,7 @@
 
 <table id="alerts">
   <tr>
+    <td>Update Time</td>
     <td>Alert</td>
     <td>Lines Affected</td>
     <td>Severity</td>

--- a/ryanwallace.cloud/map/src/index.html
+++ b/ryanwallace.cloud/map/src/index.html
@@ -3,7 +3,7 @@
   integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
   crossorigin="anonymous"
 ></script>
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-table@1.24.1/dist/bootstrap-table.min.css">
+<link rel="stylesheet" href="https://cdn.datatables.net/2.2.2/css/dataTables.dataTables.css" />
 
 <style>
   .content.container {
@@ -116,12 +116,7 @@
   >
 </p>
 
-<table id="alerts">
-  <tr>
-    <td>Update Time</td>
-    <td>Alert</td>
-    <td>Lines Affected</td>
-    <td>Severity</td>
-  </tr>
+<table id="alerts" class="display compact">
 </table>
+
 </div>

--- a/ryanwallace.cloud/map/src/index.html
+++ b/ryanwallace.cloud/map/src/index.html
@@ -3,6 +3,7 @@
   integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
   crossorigin="anonymous"
 ></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-table@1.24.1/dist/bootstrap-table.min.css">
 
 <style>
   .content.container {
@@ -19,8 +20,8 @@
   <select name="refresh-rate" id="refresh-rate">
     <option value="5">5 seconds</option>
     <option value="10">10 seconds</option>
-    <option value="15">15 seconds</option>
-    <option value="30" selected="true">30 seconds</option>
+    <option value="15" selected>15 seconds</option>
+    <option value="30">30 seconds</option>
     <option value="60">60 seconds</option>
     <option value="99999">Off</option>
   </select>
@@ -114,3 +115,12 @@
     >Mapbox Maki Icons</a
   >
 </p>
+
+<table id="alerts">
+  <tr>
+    <td>Alert</td>
+    <td>Lines Affected</td>
+    <td>Severity</td>
+  </tr>
+</table>
+</div>

--- a/ryanwallace.cloud/map/src/map.js
+++ b/ryanwallace.cloud/map/src/map.js
@@ -290,25 +290,21 @@ function onEachFeature(feature, layer) {
 }
 
 function calculateAffectedLines(data) {
+  const checks = [
+    { test: (route) => route.startsWith("CR"), class: "cr" },
+    { test: (route) => route.startsWith("7"), class: "sl" },
+    { test: (route) => route === "Blue", class: "bl" },
+    { test: (route) => route === "Red", class: "rl" },
+    { test: (route) => route === "Green", class: "gl" },
+    { test: (route) => route === "Orange", class: "ol" },
+  ];
+
   const afLines = new Set();
   for (const entity of data) {
-    if (entity.route.startsWith("CR")) {
-      afLines.add(`<small class="cr">${entity.route}</small>`);
-    }
-    if (entity.route.startsWith("7")) {
-      afLines.add(`<small class="sl">${entity.route}</small>`);
-    }
-    if (entity.route === "Blue") {
-      afLines.add(`<small class="bl">${entity.route}</small>`);
-    }
-    if (entity.route === "Red") {
-      afLines.add(`<small class="rl">${entity.route}</small>`);
-    }
-    if (entity.route === "Green") {
-      afLines.add(`<small class="gl">${entity.route}</small>`);
-    }
-    if (entity.route === "Orange") {
-      afLines.add(`<small class="ol">${entity.route}</small>`);
+    for (const check of checks) {
+      if (check.test(entity.route)) {
+        afLines.add(`<small class="${check.class}">${entity.route}</small>`);
+      }
     }
   }
   return [...afLines].join(", ");

--- a/ryanwallace.cloud/map/src/map.js
+++ b/ryanwallace.cloud/map/src/map.js
@@ -287,6 +287,61 @@ function onEachFeature(feature, layer) {
   }
 }
 
+function calculateAffectedLines(data) {
+  const afLines = new Set();
+  for (const entity of data) {
+    if (entity.route.startsWith("CR")) {
+      afLines.add(`<small class="cr">${entity.route}</small>`);
+    }
+    if (entity.route.startsWith("7")) {
+      afLines.add(`<small class="sl">${entity.route}</small>`);
+    }
+    if (entity.route === "Blue") {
+      afLines.add(`<small class="bl">${entity.route}</small>`);
+    }
+    if (entity.route === "Red") {
+      afLines.add(`<small class="rl">${entity.route}</small>`);
+    }
+    if (entity.route === "Green") {
+      afLines.add(`<small class="gl">${entity.route}</small>`);
+    }
+    if (entity.route === "Orange") {
+      afLines.add(`<small class="ol">${entity.route}</small>`);
+    }
+  }
+  return [...afLines].join(", ");
+}
+
+function alerts() {
+  $.getJSON("https://vehicles.ryanwallace.cloud/alerts", function (data) {
+    // Columns: header, lines affected, updated_at, severity
+    const table = document.getElementById("alerts");
+    const msgs = new Set();
+
+    for (const alert of data.data) {
+      if (!msgs.has(alert.attributes.header)) {
+        const row = document.createElement("tr");
+        const header = document.createElement("td");
+        header.innerHTML = `<small>${alert.attributes.header}</small>`;
+        row.appendChild(header);
+        msgs.add(alert.attributes.header);
+
+        const linesAffected = document.createElement("td");
+        linesAffected.innerHTML = calculateAffectedLines(
+          alert.attributes.informed_entity
+        );
+        row.appendChild(linesAffected);
+
+        const severity = document.createElement("td");
+        severity.textContent = alert.attributes.severity;
+        row.appendChild(severity);
+
+        table.appendChild(row);
+      }
+    }
+  });
+}
+
 function annotate_map() {
   clearMap();
   $.getJSON("https://vehicles.ryanwallace.cloud/", function (data) {
@@ -378,3 +433,5 @@ document.getElementById("refresh-rate").addEventListener("change", (event) => {
     intervalID = window.setInterval(annotate_map, event.target.value * 1000);
   }
 });
+
+alerts();

--- a/ryanwallace.cloud/map/src/map.js
+++ b/ryanwallace.cloud/map/src/map.js
@@ -6,6 +6,7 @@ import "leaflet.fullscreen";
 import "leaflet-easybutton";
 import "leaflet-arrowheads";
 import "invert-color";
+import DOMPurify from "dompurify";
 import invert from "invert-color";
 import { MaptilerLayer } from "@maptiler/leaflet-maptilersdk";
 
@@ -116,23 +117,24 @@ function updateTable() {
       const id = `${line}-${vehicleType}`;
       const element = document.getElementById(id);
       if (element) {
-        element.innerHTML = vehicleCountMap.get(line)?.get(vehicleType) || 0;
+        element.innerHTML =
+          DOMPurify.sanitize(vehicleCountMap.get(line)?.get(vehicleType)) || 0;
       }
     }
     const totalElement = document.getElementById(`${line}-total`);
     if (totalElement) {
-      totalElement.innerHTML = calculateTotal(line);
+      totalElement.innerHTML = DOMPurify.sanitize(calculateTotal(line));
     }
   }
   for (const vehicleType of vehicleTypes) {
     const element = document.getElementById(`${vehicleType}-total`);
     if (element) {
-      element.innerHTML = calculateTotal(vehicleType);
+      element.innerHTML = DOMPurify.sanitize(calculateTotal(vehicleType));
     }
   }
   const element = document.getElementById("total");
   if (element) {
-    element.innerHTML = calculateTotal("all");
+    element.innerHTML = DOMPurify.sanitize(calculateTotal("all"));
   }
 }
 
@@ -319,16 +321,19 @@ function alerts() {
     const msgs = new Set();
 
     for (const alert of data.data) {
-      if (!msgs.has(alert.attributes.header)) {
+      if (alert.attributes && !msgs.has(alert.attributes.header)) {
         const row = document.createElement("tr");
         const header = document.createElement("td");
-        header.innerHTML = `<small>${alert.attributes.header}</small>`;
+        header.innerHTML = `<small>${DOMPurify.sanitize(
+          alert.attributes.header
+        )}</small>`;
         row.appendChild(header);
         msgs.add(alert.attributes.header);
 
         const linesAffected = document.createElement("td");
-        linesAffected.innerHTML = calculateAffectedLines(
-          alert.attributes.informed_entity
+        linesAffected.innerHTML = DOMPurify.sanitize(
+          calculateAffectedLines(alert.attributes.informed_entity),
+          { ALLOWED_TAGS: ["small"] }
         );
         row.appendChild(linesAffected);
 

--- a/ryanwallace.cloud/map/src/map.js
+++ b/ryanwallace.cloud/map/src/map.js
@@ -25,6 +25,8 @@ var map = L.map("map", {
 const lines = ["rl", "gl", "bl", "ol", "sl", "cr"];
 const vehicleTypes = ["light", "heavy", "regional", "bus"];
 const vehicleCountMap = createVehicleCountMap();
+const vehicles_url =
+  process.env.VEHICLES_URL || "https://vehicles.ryanwallace.cloud";
 
 var baseLayerLoaded = false;
 
@@ -313,7 +315,7 @@ function calculateAffectedLines(data) {
 }
 
 function alerts() {
-  $.getJSON("https://vehicles.ryanwallace.cloud/alerts", function (data) {
+  $.getJSON(`${vehicles_url}/alerts`, function (data) {
     const msgs = new Set();
     const dataSet = [];
 
@@ -360,7 +362,7 @@ function alerts() {
 
 function annotate_map() {
   clearMap();
-  $.getJSON("https://vehicles.ryanwallace.cloud/", function (data) {
+  $.getJSON(vehicles_url, function (data) {
     if (geoJsonLayer) {
       map.removeLayer(geoJsonLayer);
     }
@@ -374,7 +376,7 @@ function annotate_map() {
     }, 100);
   });
   if (!baseLayerLoaded) {
-    $.getJSON("https://vehicles.ryanwallace.cloud/shapes", function (data) {
+    $.getJSON(`${vehicles_url}/shapes`, function (data) {
       var baseLayer = L.geoJSON(data, {
         style: (feature) => {
           if (feature.geometry.type === "LineString") {

--- a/ryanwallace.cloud/map/yarn.lock
+++ b/ryanwallace.cloud/map/yarn.lock
@@ -1138,6 +1138,11 @@ datatables.net@2.2.2:
   dependencies:
     jquery ">=1.7"
 
+date-fns@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
+
 detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"

--- a/ryanwallace.cloud/map/yarn.lock
+++ b/ryanwallace.cloud/map/yarn.lock
@@ -1014,6 +1014,11 @@
   dependencies:
     "@types/geojson" "*"
 
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
 ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
@@ -1118,6 +1123,21 @@ cosmiconfig@^9.0.0:
     js-yaml "^4.1.0"
     parse-json "^5.2.0"
 
+datatables.net-dt@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/datatables.net-dt/-/datatables.net-dt-2.2.2.tgz#2c7f16b08e2b10c25c65ef85eed058fa49c7d754"
+  integrity sha512-Qfe9g/E3yAPTHoDASc1J0r5Yx++3Y3VdcEOFCupvfGJ8LhRrreebUC70UYEzO8vPOKnkutoRanW/VBMRIbXKXA==
+  dependencies:
+    datatables.net "2.2.2"
+    jquery ">=1.7"
+
+datatables.net@2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/datatables.net/-/datatables.net-2.2.2.tgz#de45c9ef18775499481ffdae81a8de6a10d264a0"
+  integrity sha512-gfODIKE3gpgbVeZy2QGj2Dq9roO6hy00S+k1knklrqlMyAMrh1wt0Q6ryBUM7gU96U77ysbq8dYhxFdmcC/oPQ==
+  dependencies:
+    jquery ">=1.7"
+
 detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
@@ -1164,6 +1184,13 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
   dependencies:
     domelementtype "^2.3.0"
+
+dompurify@^3.2.5:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.5.tgz#11b108656a5fb72b24d916df17a1421663d7129c"
+  integrity sha512-mLPd29uoRe9HpvwP2TxClGQBzGXeEC/we/q+bFlmPPmj2p2Ugl3r6ATu/UU1v77DXNcehiBg9zsr1dREyA/dJQ==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 domutils@^2.8.0:
   version "2.8.0"
@@ -1374,7 +1401,7 @@ isexe@^3.1.1:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-3.1.1.tgz#4a407e2bd78ddfb14bea0c27c6f7072dde775f0d"
   integrity sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==
 
-jquery@^3.7.1:
+jquery@>=1.7, jquery@^3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.1.tgz#083ef98927c9a6a74d05a6af02806566d16274de"
   integrity sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==

--- a/ryanwallace.cloud/map/yarn.lock
+++ b/ryanwallace.cloud/map/yarn.lock
@@ -1374,6 +1374,11 @@ isexe@^3.1.1:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-3.1.1.tgz#4a407e2bd78ddfb14bea0c27c6f7072dde775f0d"
   integrity sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==
 
+jquery@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.1.tgz#083ef98927c9a6a74d05a6af02806566d16274de"
+  integrity sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==
+
 js-base64@^3.7.7:
   version "3.7.7"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.7.tgz#e51b84bf78fbf5702b9541e2cb7bfcb893b43e79"


### PR DESCRIPTION
Adds and alerting section to the MBTA tracker.

![Screenshot 2025-04-04 at 4 14 57 PM](https://github.com/user-attachments/assets/86c0710f-1e7d-4579-9f0e-6cd7e82301e1)


## Summary by Sourcery

Add an alerts section to the MBTA tracker map to display real-time transit alerts

New Features:
- Implement a new alerts table that shows current MBTA transit alerts with severity, update time, description, and affected lines

Enhancements:
- Improve data sanitization by using DOMPurify to prevent XSS attacks
- Add dynamic formatting for alert display using DataTables

Build:
- Update package.json dependencies to include new libraries like datatables.net, date-fns, and dompurify