### PR TITLE
remove arrowheads and replace with links to stations

### DIFF
--- a/ryanwallace.cloud/map/src/amtrak.ts
+++ b/ryanwallace.cloud/map/src/amtrak.ts
@@ -9,6 +9,9 @@ declare const $: {
 
 export function fetchAmtrakData(bos_url: string): void {
   $.getJSON(`${bos_url}/trains/geojson`, function (data: any) {
+    // Clear existing Amtrak markers before adding new ones
+    layerGroups.amtrak.clearLayers()
+
     if (data && data.features) {
       L.geoJSON(data, {
         pointToLayer: (feature: any, latlng: L.LatLng) => {

--- a/ryanwallace.cloud/map/src/map.ts
+++ b/ryanwallace.cloud/map/src/map.ts
@@ -71,17 +71,22 @@ function annotate_map(): void {
     // Update vehicle markers efficiently
     updateMarkers(data.features || [])
 
-    // Handle building markers (static, so only create once if needed)
-    if (!buildingMarkers) {
-      buildingMarkers = L.geoJSON(data, {
+    // Handle building markers (stops) - refresh their data each time but keep them displayed
+    const buildingFeatures = data.features.filter(
+      (feature: any) => feature.properties['marker-symbol'] === 'building'
+    )
+
+    if (!buildingMarkers && buildingFeatures.length > 0) {
+      buildingMarkers = L.geoJSON(buildingFeatures, {
         pointToLayer: pointToLayer as any,
-        onEachFeature: onEachFeature as any,
-        filter: (feature) => {
-          return feature.properties['marker-symbol'] === 'building'
-        }
+        onEachFeature: onEachFeature as any
       }).addTo(map)
       // Make buildingMarkers accessible globally
       window.buildingMarkers = buildingMarkers
+    } else if (buildingMarkers && buildingFeatures.length > 0) {
+      // Update existing building markers with new data
+      buildingMarkers.clearLayers()
+      buildingMarkers.addData(buildingFeatures)
     }
 
     console.log('Map loaded')

--- a/ryanwallace.cloud/map/src/marker-manager.ts
+++ b/ryanwallace.cloud/map/src/marker-manager.ts
@@ -58,8 +58,35 @@ export function updateMarkers(features: VehicleFeature[]): void {
         platform_prediction = `<br />Platform Prediction: ${feature.properties['platform_prediction']}`
       }
 
+      let stopDisplay = feature.properties.stop || ''
+      if (feature.properties.stop) {
+        // Don't create stop links for Amtrak trains since their stop data isn't reliable
+        const isAmtrak =
+          feature.properties.route &&
+          (feature.properties.route.toLowerCase().includes('amtrak') ||
+            feature.properties.route.toLowerCase().includes('acela') ||
+            feature.properties.route
+              .toLowerCase()
+              .includes('northeast regional'))
+
+        if (!isAmtrak) {
+          let coords = feature.properties['stop-coordinates']
+
+          // Fallback to vehicle coordinates if stop coordinates are missing
+          if (!coords || coords.length < 2) {
+            coords = feature.geometry.coordinates
+          }
+
+          if (coords && coords.length >= 2) {
+            const lat = coords[1]
+            const lng = coords[0]
+            stopDisplay = `<a href="#" onclick="window.moveMapToStop(${lat}, ${lng}); return false;" class="popup-link">${feature.properties.stop}</a>`
+          }
+        }
+      }
+
       const popupContent = `<b>${feature.properties.route}/<i>${feature.properties.headsign || feature.properties.stop}</i></b>
-        <br />Stop: ${feature.properties.stop || ''}
+        <br />Stop: ${stopDisplay}
         <br />Status: ${niceStatus(feature.properties.status || '')}
         ${eta}${speed}${occupancy}${platform_prediction}
         <br /><small>Update Time: ${update_time.toLocaleTimeString()}</small>`

--- a/ryanwallace.cloud/map/src/markers.ts
+++ b/ryanwallace.cloud/map/src/markers.ts
@@ -152,7 +152,8 @@ export function updateVehicleFeatures(features: VehicleFeature[]): void {
         layer.feature &&
         layer.feature.properties['marker-symbol'] === 'building'
       ) {
-        const stopName = layer.feature.properties.name || 'Unknown Stop'
+        const stopName =
+          layer.feature.properties.name.replace('stop', '') || 'Unknown Stop'
         const incomingVehicles = getIncomingVehicles(stopName)
 
         let vehicleInfo = ''


### PR DESCRIPTION
Remove the arrowhead pointing to stations since that did not work with the move to more efficient vehicle loading. Instead, we use links that trigger the map to go to that specific viewport. Additionally, some stations display ETAs of oncoming trains/buses.