### PR TITLE
fullscreen fixes for iOS

### DIFF
--- a/ryanwallace.cloud/assets/css/custom.css
+++ b/ryanwallace.cloud/assets/css/custom.css
@@ -475,7 +475,11 @@ body.dark-theme .pagination-item:hover {
 .leaflet-container:fullscreen {
   width: 100% !important;
   height: 100% !important;
-  z-index: 99999;
+  z-index: 2147483647 !important;
+  margin: 0 !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  transition: none !important;
 }
 
 .leaflet-pseudo-fullscreen {
@@ -484,11 +488,61 @@ body.dark-theme .pagination-item:hover {
   height: 100% !important;
   top: 0 !important;
   left: 0 !important;
-  z-index: 99999;
+  z-index: 2147483647 !important;
+  /* Prevent site styles from clipping or offsetting pseudo fullscreen */
+  margin: 0 !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  transition: none !important;
+  min-height: 0 !important;
 }
 
-.leaflet-zoom-animated canvas {
+/* Scope canvas height tweak to pseudo fullscreen only to avoid distortions */
+.leaflet-pseudo-fullscreen .leaflet-zoom-animated canvas {
   height: 100% !important;
+}
+
+/* Nudge Leaflet controls inside iOS safe areas during fullscreen */
+.leaflet-container:-webkit-full-screen .leaflet-top,
+.leaflet-container:fullscreen .leaflet-top,
+.leaflet-pseudo-fullscreen .leaflet-top {
+  top: max(0px, env(safe-area-inset-top)) !important;
+}
+.leaflet-container:-webkit-full-screen .leaflet-bottom,
+.leaflet-container:fullscreen .leaflet-bottom,
+.leaflet-pseudo-fullscreen .leaflet-bottom {
+  bottom: max(0px, env(safe-area-inset-bottom)) !important;
+}
+.leaflet-container:-webkit-full-screen .leaflet-left,
+.leaflet-container:fullscreen .leaflet-left,
+.leaflet-pseudo-fullscreen .leaflet-left {
+  left: max(0px, env(safe-area-inset-left)) !important;
+}
+.leaflet-container:-webkit-full-screen .leaflet-right,
+.leaflet-container:fullscreen .leaflet-right,
+.leaflet-pseudo-fullscreen .leaflet-right {
+  right: max(0px, env(safe-area-inset-right)) !important;
+}
+
+/* When map fullscreen is active, neutralize transforms on nearby ancestors */
+.map-fs-no-transform {
+  transform: none !important;
+  will-change: auto !important;
+}
+
+/* Remove overflow clipping on ancestors while map fullscreen is active */
+.map-fs-no-overflow {
+  overflow: visible !important;
+  border-radius: 0 !important;
+}
+
+/* Prevent background page scroll while map is fullscreen */
+html.map-fs-active,
+body.map-fs-active {
+  overflow: hidden !important;
+  overscroll-behavior: contain;
+  height: 100% !important;
+  overscroll-behavior-y: none;
 }
 
 .easy-button-button {

--- a/ryanwallace.cloud/assets/css/custom.css
+++ b/ryanwallace.cloud/assets/css/custom.css
@@ -472,6 +472,7 @@ body.dark-theme .pagination-item:hover {
 /* Safari still needs this vendor-prefix: https://caniuse.com/mdn-css_selectors_fullscreen */
 /* stylelint-disable-next-line selector-no-vendor-prefix */
 .leaflet-container:-webkit-full-screen,
+.leaflet-container:-moz-full-screen,
 .leaflet-container:fullscreen {
   width: 100% !important;
   height: 100% !important;
@@ -489,7 +490,6 @@ body.dark-theme .pagination-item:hover {
   top: 0 !important;
   left: 0 !important;
   z-index: 2147483647 !important;
-  /* Prevent site styles from clipping or offsetting pseudo fullscreen */
   margin: 0 !important;
   border-radius: 0 !important;
   box-shadow: none !important;
@@ -497,9 +497,21 @@ body.dark-theme .pagination-item:hover {
   min-height: 0 !important;
 }
 
-/* Avoid forcing canvas sizing; let Leaflet manage intrinsic size for stability */
+.leaflet-container.map-fs-on .map-expand-button,
+.leaflet-pseudo-fullscreen .map-expand-button,
+.leaflet-container:-webkit-full-screen .map-expand-button,
+.leaflet-container:-moz-full-screen .map-expand-button,
+.leaflet-container:fullscreen .map-expand-button {
+  display: none !important;
+}
+.leaflet-container.map-fs-on .easy-button-button:has(.expand),
+.leaflet-pseudo-fullscreen .easy-button-button:has(.expand),
+.leaflet-container:-webkit-full-screen .easy-button-button:has(.expand),
+.leaflet-container:-moz-full-screen .easy-button-button:has(.expand),
+.leaflet-container:fullscreen .easy-button-button:has(.expand) {
+  display: none !important;
+}
 
-/* Nudge Leaflet controls inside iOS safe areas during fullscreen */
 .leaflet-container:-webkit-full-screen .leaflet-top,
 .leaflet-container:fullscreen .leaflet-top,
 .leaflet-pseudo-fullscreen .leaflet-top {
@@ -520,20 +532,14 @@ body.dark-theme .pagination-item:hover {
 .leaflet-pseudo-fullscreen .leaflet-right {
   right: max(0px, env(safe-area-inset-right)) !important;
 }
-
-/* When map fullscreen is active, neutralize transforms on nearby ancestors */
 .map-fs-no-transform {
   transform: none !important;
   will-change: auto !important;
 }
-
-/* Remove overflow clipping on ancestors while map fullscreen is active */
 .map-fs-no-overflow {
   overflow: visible !important;
   border-radius: 0 !important;
 }
-
-/* Prevent background page scroll while map is fullscreen */
 html.map-fs-active,
 body.map-fs-active {
   overflow: hidden !important;

--- a/ryanwallace.cloud/assets/css/custom.css
+++ b/ryanwallace.cloud/assets/css/custom.css
@@ -497,10 +497,7 @@ body.dark-theme .pagination-item:hover {
   min-height: 0 !important;
 }
 
-/* Scope canvas height tweak to pseudo fullscreen only to avoid distortions */
-.leaflet-pseudo-fullscreen .leaflet-zoom-animated canvas {
-  height: 100% !important;
-}
+/* Avoid forcing canvas sizing; let Leaflet manage intrinsic size for stability */
 
 /* Nudge Leaflet controls inside iOS safe areas during fullscreen */
 .leaflet-container:-webkit-full-screen .leaflet-top,

--- a/ryanwallace.cloud/map/package.json
+++ b/ryanwallace.cloud/map/package.json
@@ -54,7 +54,7 @@
   },
   "packageManager": "pnpm@10.15.0",
   "scripts": {
-    "build": "webpack --config webpack.config.js --mode production",
+    "build": "webpack --config webpack.config.js",
     "build:dev": "webpack --config webpack.config.js --mode development",
     "build:nocache": "webpack --config webpack.config.js --mode production --no-cache",
     "move": "mkdir -p ../static/map; mkdir -p ../content/map; mv dist/* ../content/map/",

--- a/ryanwallace.cloud/map/src/map.ts
+++ b/ryanwallace.cloud/map/src/map.ts
@@ -54,7 +54,7 @@ var map = L.map('map', {
   fullscreenControlOptions: {
     position: 'topleft',
     title: 'Fullscreen',
-    forcePseudoFullscreen: true
+    forcePseudoFullscreen: false
   },
   preferCanvas: true,
   maxZoom: 50

--- a/ryanwallace.cloud/map/src/map.ts
+++ b/ryanwallace.cloud/map/src/map.ts
@@ -143,22 +143,7 @@ map.on('enterFullscreen', () => {
   const wasExpanded = isMapExpanded
   if (wasExpanded) setMapExpanded(false)
   if (isIOS()) {
-    // Freeze background scroll (prefer pre-captured scroll from preToggle)
-    const capturedY = _fsPreScrollY
-    _fsPreScrollY = null
-    _fsScrollY =
-      typeof capturedY === 'number'
-        ? capturedY
-        : window.scrollY || window.pageYOffset || 0
-    const bs = document.body.style
-    bs.position = 'fixed'
-    bs.top = `-${_fsScrollY}px`
-    bs.left = '0'
-    bs.right = '0'
-    bs.width = '100%'
-    bs.overflow = 'hidden'
-
-    // Add a body flag for CSS-based safe-area adjustments (after freezing)
+    // Add a body flag for CSS-based safe-area adjustments and scroll lock
     document.body.classList.add('map-fs-active')
     document.documentElement.classList.add('map-fs-active')
   }
@@ -197,21 +182,10 @@ map.on('exitFullscreen', () => {
       n.classList.remove('map-fs-no-overflow')
     }
     _fsAncestors = []
-    // Unfreeze background scroll and restore position
+    // Remove scroll blockers
     if (_removeScrollBlockers) {
       _removeScrollBlockers()
       _removeScrollBlockers = null
-    }
-    const bs = document.body.style
-    bs.position = ''
-    bs.top = ''
-    bs.left = ''
-    bs.right = ''
-    bs.width = ''
-    bs.overflow = ''
-    if (typeof _fsScrollY === 'number') {
-      window.scrollTo(0, _fsScrollY)
-      _fsScrollY = 0
     }
   }
   // Invalidate after exit to settle tiles


### PR DESCRIPTION
Get fullscreen working on iOS through some workarounds. Also prevent collisions between the expanded mode + fullscreen as well as disable that button in fullscreen mode.